### PR TITLE
Reimplement packer and unpacker completely.

### DIFF
--- a/earl.cpp
+++ b/earl.cpp
@@ -6,13 +6,24 @@
  */
 
 // Includes
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <string>
 #include <vector>
 #include <stdio.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdint.h>
 #include <algorithm>
+#include <stdexcept>
+#include <iostream>
+
+#if defined(_MSC_VER) && _MSC_VER
+#include <iso646.h>
+#endif
 
 // External Term Format Defines
+const char FORMAT_VERSION = '\x83';
 const char FLOAT_IEEE_EXT = 'F';
 const char BIT_BINARY_EXT = 'M';
 const char SMALL_INTEGER_EXT = 'a';
@@ -28,1055 +39,918 @@ const char SMALL_BIG_EXT = 'n';
 const char LARGE_BIG_EXT = 'o';
 const char MAP_EXT = 't';
 const char ATOM_EXT = 'd';
+const char SMALL_ATOM_EXT = 's';
 const char ATOM_UTF_EXT = 'v';
 const char ATOM_UTF_SMALL_EXT = 'w';
+const char COMPRESSED_TERM = 'P';
 
-#if _MSC_VER // MSVC doesn't support keywords
-#include <iso646.h>
-#endif
-
-
-// Function Prototypes
-// Packing Functions
-std::string etfp_small_int(long value);
-std::string etfp_big_int(long value);
-std::string etfp_string(PyObject* value);
-std::string etfp_float(double value);
-std::string etfp_tuple(PyObject* tuple);
-std::string etfp_set(PyObject* set);
-std::string etfp_list(PyObject* list);
-std::string etfp_dict(PyObject* dict);
-std::string etfp_atom_utf(PyObject* text);
-std::string etf_pack_item(PyObject* object);
-// Unpacking Functions
-PyObject* etfup_bytes(PyObject* item);
-PyObject* etfup_item(char *buffer, int &pos);
-PyObject* etfup_small_int(char *buffer, int &pos);
-PyObject* etfup_int(char *buffer, int &pos);
-PyObject* etfup_float_old(char *buffer, int &pos);
-PyObject* etfup_float_new(char *buffer, int &pos);
-PyObject* etfup_tuple(char *buffer, int &pos);
-PyObject* etfup_list(char *buffer, int &pos);
-PyObject* etfup_map(char *buffer, int &pos);
-PyObject* etfup_atom(char *buffer, int &pos);
-PyObject* etfup_atom_utf(char *buffer, int &pos);
-PyObject* etfup_atom_utf_small(char *buffer, int &pos);
-PyObject* etfup_string(char *buffer, int &pos);
-PyObject* etfup_binary(char *buffer, int &pos);
-// Extern C Functions
 extern "C" {
-  static PyObject* earl_pack(PyObject* self, PyObject* args);
-  static PyObject* earl_unpack(PyObject* self, PyObject* args);
-}
-// End Function Prototypes
-
-std::string etfp_small_int(long value){
-
-  std::string buffer(1, SMALL_INTEGER_EXT);
-  buffer.push_back(char(value));
-  return buffer;
-
+static PyObject* earl_pack(PyObject* self, PyObject* args, PyObject* kwargs);
+static PyObject* earl_unpack(PyObject* self, PyObject* args, PyObject* kwargs);
+// our custom exception types
+PyObject* earl_DecodeError;
+PyObject* earl_EncodeError;
 }
 
-std::string etfp_big_int(long value){
+enum encode_type {
+    str = 0,
+    bytes = 1,
+    atom = 2
+};
 
-  int temp = int(value);
-
-  std::string buffer(1, INTEGER_EXT);
-  buffer.push_back(((temp >> 24) & 0xFF));
-  buffer.push_back(((temp >> 16) & 0xFF));
-  buffer.push_back(((temp >> 8) & 0xFF));
-  buffer.push_back((temp & 0xFF));
-
-  return buffer;
-
+template<typename T>
+static T from_big_endian(const char* bytes) {
+    const unsigned char* r = reinterpret_cast<const unsigned char*>(bytes);
+    Py_ssize_t i = sizeof(T);
+    T length = 0;
+    do { length = length << 8 | *r++; } while(--i > 0);
+    return length;
 }
 
-std::string etfp_string(PyObject *value){
-
-  char *buffer;
-  Py_ssize_t pbl;
-
-  if( PyBytes_AsStringAndSize(value, &buffer, &pbl) == -1 ){
-
-    PyErr_SetString(PyExc_RuntimeError, "Unable to convert the bytes object to a char array.");
-    return NULL;
-
-  }
-
-  std::string byte_stream(1, STRING_EXT);
-  byte_stream.append(buffer, pbl);
-  return byte_stream;
-
+static void as_big_endian32(unsigned char* buffer, uint32_t integer) {
+    buffer[0] = integer >> 24;
+    buffer[1] = integer >> 16;
+    buffer[2] = integer >> 8;
+    buffer[3] = integer >> 0;
 }
 
-std::string etfp_float(double value){
-
-  // This doesn't work right now
-
-  std::string buffer(1, FLOAT_IEEE_EXT);
-
-  char *raw = (char*)(&value);
-  std::reverse(&raw, &raw + sizeof(double));
-
-  for (int i={0}; i < sizeof(raw); i++){
-
-    buffer.append(raw[i], 1);
-
-  }
-
-  return buffer;
-
+static void as_big_endian16(unsigned char* buffer, uint16_t integer) {
+    buffer[0] = integer >> 8;
+    buffer[1] = integer >> 0;
 }
 
-std::string etfp_tuple(PyObject* tuple){
-
-  Py_ssize_t len = PyTuple_Size(tuple);
-  std::string buffer(1, (len > 256 ? LARGE_TUPLE_EXT : SMALL_TUPLE_EXT));
-
-  if( len > 256 ){
-
-    buffer.push_back(((len >> 24) & 0xFF));
-    buffer.push_back(((len >> 16) & 0xFF));
-    buffer.push_back(((len >> 8) & 0xFF));
-    buffer.push_back((len & 0xFF));
-
-  } else {
-
-    buffer.push_back((len & 0xFF));
-
-  }
-
-  for( int ii={0}; ii < len; ii++ ){
-
-      PyObject* temp = PyTuple_GetItem(tuple, ii);
-
-      buffer += etf_pack_item(temp);
-
-  }
-
-  if( !PyErr_Occurred() ){
-
-    return buffer;
-
-  } else {
-
-    return NULL;
-
-  }
-
+static void as_big_endian64(unsigned char* buffer, uint64_t integer) {
+    buffer[0] = integer >> 56;
+    buffer[1] = integer >> 48;
+    buffer[2] = integer >> 40;
+    buffer[3] = integer >> 32;
+    buffer[4] = integer >> 24;
+    buffer[5] = integer >> 16;
+    buffer[6] = integer >> 8;
+    buffer[7] = integer >> 0;
 }
 
-std::string etfp_set(PyObject* set){
-
-  Py_ssize_t len = PySet_Size(set);
-  std::string buffer(1, LIST_EXT);
-
-  buffer.push_back(((len >> 24) & 0xFF));
-  buffer.push_back(((len >> 16) & 0xFF));
-  buffer.push_back(((len >> 8) & 0xFF));
-  buffer.push_back((len & 0xFF));
-
-  for( int ii={0}; ii < len; ii++ ){
-
-    PyObject* temp = PySet_Pop(set);
-    buffer += etf_pack_item(temp);
-
-  }
-
-  if( !PyErr_Occurred() ){
-
-    buffer.push_back(NIL_EXT);
-    return buffer;
-
-  } else {
-
-    return NULL;
-
-  }
-
-}
-
-std::string etfp_list(PyObject* list){
-
-  Py_ssize_t len = PyList_Size(list);
-  std::string buffer(1, LIST_EXT);
-
-  buffer.push_back(((len >> 24) & 0xFF));
-  buffer.push_back(((len >> 16) & 0xFF));
-  buffer.push_back(((len >> 8) & 0xFF));
-  buffer.push_back((len & 0xFF));
-
-  for( int ii={0}; ii < len; ii++ ){
-
-    PyObject* temp = PyList_GetItem(list, ii);
-    buffer += etf_pack_item(temp);
-
-  }
-
-  if( !PyErr_Occurred() ){
-
-    buffer.push_back(NIL_EXT);
-    return buffer;
-
-  } else {
-
-    return NULL;
-
-  }
-
-}
-
-std::string etfp_dict(PyObject* dict){
-
-  Py_ssize_t len = PyDict_Size(dict);
-  std::string buffer(1, MAP_EXT);
-
-  buffer.push_back(((len >> 24) & 0xFF));
-  buffer.push_back(((len >> 16) & 0xFF));
-  buffer.push_back(((len >> 8) & 0xFF));
-  buffer.push_back((len & 0xFF));
-
-  len = 0;
-  PyObject *k, *v;
-
-  while( PyDict_Next(dict, &len, &k, &v) ){
-
-    buffer += etf_pack_item(k);
-    buffer += etf_pack_item(v);
-
-  }
-
-  if( !PyErr_Occurred() ){
-
-    return buffer;
-
-  } else {
-
-    return NULL;
-
-  }
-
-}
-
-std::string etfp_atom_utf(PyObject* temp){
-
-  PyObject* utf8_str = PyUnicode_AsUTF8String(temp);
-
-  if( !utf8_str ){
-
-    if( !PyErr_Occurred() ){
-
-      PyErr_SetString(PyExc_RuntimeError, "Failed to process the python string.");
-
-    }
-
-    return NULL;
-
-  } else {
-
-    std::string buffer(1, ATOM_UTF_EXT);
-
-    char *byte_stream;
-    Py_ssize_t pbl;
-
-    if( PyBytes_AsStringAndSize(utf8_str, &byte_stream, &pbl) == -1 ){
-
-      if( !PyErr_Occurred() ){
-
-        PyErr_SetString(PyExc_RuntimeError, "Unable to convert the UTF8 string to bytes.");
-
-      }
-
-      return NULL;
-
-    } else {
-
-        if( pbl > 0 ){
-
-          buffer.push_back((pbl >> 8) & 0xFF);
-          buffer.push_back(pbl & 0xFF);
-          buffer.append(byte_stream, pbl);
-
-        } else {
-
-          buffer.push_back((pbl >> 8) & 0xFF);
-          buffer.push_back(pbl & 0xFF);
-
-        }
-
-        return buffer;
-
-    }
-
-  }
-
-}
-
-std::string etf_pack_item(PyObject* temp){
-
-  std::string buffer;
-
-  if( PyLong_Check(temp) and !PyBool_Check(temp) ){
-
-    long temp_int = PyLong_AsLong(temp);
-
-    if ( temp_int > 0 and temp_int < 255 ){
-
-      buffer += etfp_small_int(temp_int);
-
-    } else if( temp_int > -2147483647 and temp_int < 2147483647 ){
-
-      buffer += etfp_big_int(temp_int);
-
-    } else {
-
-      if( !PyErr_Occurred() ){
-
-        PyErr_SetString(PyExc_RuntimeError, "Number too large to pack.");
-
-      }
-
-    }
-
-  } else if( PyUnicode_Check(temp) ) {
-
-    if( PyUnicode_READY(temp) != 0 ){
-
-      if( !PyErr_Occurred() ){
-
-        PyErr_SetString(PyExc_RuntimeError, "Earl wasn't able to migrate the Python Unicode data to memory.");
-
-      }
-
-    }else{
-
-      buffer += etfp_atom_utf(temp);
-
-    }
-
-  }else if( PyFloat_Check(temp) ){
-
-    buffer += etfp_float(PyFloat_AsDouble(temp));
-
-  }else if( PyTuple_Check(temp) ){
-
-    buffer += etfp_tuple(temp);
-
-  }else if( PySet_Check(temp) ){
-
-    buffer += etfp_set(temp);
-
-  }else if( PyList_Check(temp) ){
-
-    buffer += etfp_list(temp);
-
-  }else if( PyDict_Check(temp) ){
-
-    buffer += etfp_dict(temp);
-
-  }else if( PyBytes_Check(temp) ){
-
-    buffer += etfp_string(temp);
-
-  }else if( PyBool_Check(temp) ){
-
-    if( PyObject_IsTrue(temp) ){
-
-      buffer.push_back(ATOM_EXT);
-      buffer.push_back((4 >> 8) & 0xFF);
-      buffer.push_back(4 & 0xFF);
-      buffer += "true";
-
-    } else {
-
-      buffer.push_back(ATOM_EXT);
-      buffer.push_back((5 >> 8) & 0xFF);
-      buffer.push_back(5 & 0xFF);
-      buffer += "false";
-
-    }
-
-  }else if( temp == Py_None ){
-
-    buffer.push_back(ATOM_EXT);
-    buffer.push_back((3 >> 8) & 0xFF);
-    buffer.push_back(3 & 0xFF);
-    buffer += "nil";
-
-  }else{
-
-    if ( !PyErr_Occurred() ){
-
-      PyErr_SetString(PyExc_TypeError, "Earl can't pack one of the types you gave it!");
-
-    }
-
-  }
-
-  return buffer;
-
-}
-
-
-PyObject* etfup_bytes(PyObject* item, Py_ssize_t len){
-
-    char *buffer;
-    Py_ssize_t pbl;
-
-    if( PyBytes_AsStringAndSize(item, &buffer, &pbl) == -1 ){
-
-      PyErr_SetString(PyExc_RuntimeError, "Unable to convert the bytes object to a char array.");
-      return NULL;
-
-    }
-
-    std::vector<PyObject*> objects;
-    int pos = 1;  // ignore the first char. It just signifies version.
-
-    for( pos; pos < len; pos++ ){
-
-      if( buffer[pos] == INTEGER_EXT or buffer[pos] == SMALL_INTEGER_EXT ){
-
-        if( buffer[pos] == INTEGER_EXT ){
-
-          objects.push_back(etfup_int(buffer, pos));
-
-        } else {
-
-          objects.push_back(etfup_small_int(buffer, pos));
-
-        }
-
-      } else if( buffer[pos] == FLOAT_IEEE_EXT or buffer[pos] == FLOAT_EXT ){
-
-        if( buffer[pos] == FLOAT_IEEE_EXT ){
-
-          objects.push_back(etfup_float_new(buffer, pos));
-
-        } else {
-
-          objects.push_back(etfup_float_old(buffer, pos));
-
-        }
-
-      } else if( buffer[pos] == LIST_EXT ){
-
-        objects.push_back(etfup_list(buffer, pos));
-
-      } else if( buffer[pos] == MAP_EXT ){
-
-        objects.push_back(etfup_map(buffer, pos));
-
-      } else if( buffer[pos] == ATOM_UTF_EXT ){
-
-        objects.push_back(etfup_atom_utf(buffer, pos));
-
-      } else if( buffer[pos] == SMALL_TUPLE_EXT or buffer[pos] == LARGE_TUPLE_EXT ){
-
-        objects.push_back(etfup_tuple(buffer, pos));
-
-      } else if( buffer[pos] == ATOM_UTF_SMALL_EXT ){
-
-        objects.push_back(etfup_atom_utf_small(buffer, pos));
-
-      } else if( buffer[pos] == ATOM_EXT ){
-
-        objects.push_back(etfup_atom(buffer, pos));
-
-      } else if( buffer[pos] == STRING_EXT ){
-
-        objects.push_back(etfup_string(buffer, pos));
-
-      } else if( buffer[pos] == BINARY_EXT ){
-
-        objects.push_back(etfup_binary(buffer, pos));
-
-      }
-
-    }
-
-  if( objects.size() > 1 ){
-
-    PyObject* tlist = PyList_New(objects.size());
-
-    for( unsigned ii={0}; ii < objects.size(); ii++ ){
-
-      if( PyList_SetItem(tlist, ii, objects[ii]) != 0 ){
-
-        if( !PyErr_Occurred() ){
-
-          PyErr_SetString(PyExc_RuntimeError, "Earl encountered an error building the python objects.");
-
-        }
-
-        return NULL;
-
-      }
-
-    }
-
-    return tlist;
-
-  } else {
-
-    return objects[0];
-
-  }
-
-}
-
-PyObject* etfup_item(char *buffer, int &pos){
-
-  if( buffer[pos] == SMALL_INTEGER_EXT ){
-
-    return etfup_small_int(buffer, pos);
-
-  } else if( buffer[pos] == INTEGER_EXT ){
-
-    return etfup_int(buffer, pos);
-
-  } else if( buffer[pos] == FLOAT_EXT ){
-
-    return etfup_float_old(buffer, pos);
-
-  } else if( buffer[pos] == FLOAT_IEEE_EXT ){
-
-    return etfup_float_new(buffer, pos);
-
-  } else if( buffer[pos] == LIST_EXT ){
-
-    return etfup_list(buffer, pos);
-
-  } else if( buffer[pos] == MAP_EXT ){
-
-    return etfup_map(buffer, pos);
-
-  } else if( buffer[pos] == ATOM_UTF_EXT ){
-
-    return etfup_atom_utf(buffer, pos);
-
-  } else if( buffer[pos] == ATOM_UTF_SMALL_EXT ){
-
-    return etfup_atom_utf_small(buffer, pos);
-
-  } else if( buffer[pos] == SMALL_TUPLE_EXT or buffer[pos] == LARGE_TUPLE_EXT ){
-
-    return etfup_tuple(buffer, pos);
-
-  } else if( buffer[pos] == ATOM_EXT ){
-
-    return etfup_atom(buffer, pos);
-
-  } else if( buffer[pos] == STRING_EXT ){
-
-    return etfup_string(buffer, pos);
-
-  } else if( buffer[pos] == BINARY_EXT ){
-
-    return etfup_binary(buffer, pos);
-
-  } else {
-
-    if( !PyErr_Occurred() ){
-
-      PyErr_SetString(PyExc_RuntimeError, "Couldn't unpack the given types.");
-      return NULL;
-
-    }
-
-  }
-
-  return NULL;
-
-}
-
-PyObject* etfup_small_int(char *buffer, int &pos){
-
-  pos++;
-  long upd = int(buffer[pos]);
-
-  if ( upd < 0 ){
-
-    upd = 127 + (128 - (upd*-1)) + 1;
-
-  }
-
-  pos++;
-
-  return PyLong_FromLong(upd);
-
-}
-
-PyObject* etfup_int(char *buffer, int &pos){
-
-  pos += 1;
-  int upd = 0;
-
-  for( unsigned nb = 0; nb < sizeof(upd); nb++ ){
-
-    upd = (upd << 8) + static_cast<unsigned char>(buffer[pos+nb]);
-
-  }
-
-  pos += 4;
-
-  return PyLong_FromLong(long(upd));
-
-}
-
-PyObject* etfup_float_new(char *buffer, int &pos){
-
-  // This doesn't work yet
-
-  pos += 1;
-  double upd;
-
-  memcpy(&upd, &pos, sizeof(double));
-
-  pos += 8;
-
-  return PyFloat_FromDouble(upd);
-
-}
-
-PyObject* etfup_float_old(char *buffer, int &pos){
-
-  // Theoretically this works?
-
-  double upd = 0.0;
-  pos += 1;
-  char substr[31];
-
-  for( unsigned nb = 0; nb < 31; nb ++){
-
-    substr[nb] = buffer[pos+nb];
-
-  }
-
-  sscanf(substr, "%lf", &upd);
-  pos += 31;
-  return PyFloat_FromDouble(upd);
-
-}
-
-PyObject* etfup_tuple(char *buffer, int &pos){
-
-  int len = 0;
-  if( buffer[pos] == SMALL_TUPLE_EXT ){
-
-    len = (len << 8) + buffer[pos+1];
-    pos += 2;
-
-  } else {
-
-    for( int ii={1}; ii < 5; ii++){
-
-      len = (len << 8) + buffer[pos+ii];
-
-    }
-    pos += 5;
-
-  }
-
-  PyObject* tuple = PyTuple_New(len);
-
-  for( int ii={0}; ii < len; ii++ ){
-
-    if( PyTuple_SetItem(tuple, ii, etfup_item(buffer, pos)) != 0 ){
-
-      if( !PyErr_Occurred() ){
-
-        PyErr_SetString(PyExc_RuntimeError, "Error populating Tuple object.");
-
-      }
-
-    }
-
-  }
-
-  return tuple;
-
-}
-
-PyObject* etfup_list(char *buffer, int &pos){
-
-  int len = 0;
-  len = (len << 8) + buffer[pos+1];
-  len = (len << 8) + buffer[pos+2];
-  len = (len << 8) + buffer[pos+3];
-  len = (len << 8) + buffer[pos+4];
-  pos += 5;
-
-  PyObject* list = PyList_New(len);
-
-  for( int ii={0}; ii < len; ii++ ){
-
-    if( buffer[pos] == NIL_EXT ){
-
-      pos++;
-
-    } else {
-
-      if( PyList_SetItem(list, ii, etfup_item(buffer, pos)) != 0 ){
-
-        if( !PyErr_Occurred() ){
-
-          PyErr_SetString(PyExc_RuntimeError, "Unable to build Python List.");
-
-        }
-
-      }
-
-    }
-
-  }
-
-  if( buffer[pos] == NIL_EXT ){
-
-    pos += 1;
-
-  }
-
-  return list;
-
-}
-
-PyObject* etfup_map(char *buffer, int &pos){
-
-  int len = 0;
-  len = (len << 8) + buffer[pos+1];
-  len = (len << 8) + buffer[pos+2];
-  len = (len << 8) + buffer[pos+3];
-  len = (len << 8) + buffer[pos+4];
-  pos += 5;
-
-  PyObject* dict = PyDict_New();
-
-  std::vector<PyObject*> keys, values;
-
-  for( int ii={0}; ii < (len*2); ii++ ){
-
-    if( ii % 2 ){
-
-      values.push_back(etfup_item(buffer, pos));
-
-    } else {
-
-      keys.push_back(etfup_item(buffer,pos));
-
-    }
-
-  }
-
-  if (keys.size() != values.size()){
-
-    if( !PyErr_Occurred() ){
-
-      PyErr_SetString(PyExc_RuntimeError, "Dictionary has an uneven amount of keys and values.");
-      return NULL;
-
-    }
-
-  }
-
-  for( unsigned ii={0}; ii < keys.size(); ii++ ){
-
-    if( PyDict_SetItem(dict, keys[ii], values[ii]) != 0 ){
-
-      if( !PyErr_Occurred() ){
-
-        PyErr_SetString(PyExc_RuntimeError, "Error building the Python Dictionary.");
-        return NULL;
-
-      }
-
-    }
-
-  }
-
-  return dict;
-
-}
-
-PyObject* etfup_atom(char* buffer, int &pos){
-
-  int length = 0;
-  length = (length << 8) + buffer[pos+1];
-  length = (length << 8) + buffer[pos+2];
-  pos += 3;
-
-  std::string strbuf;
-
-  for( int nb = 0; nb < length; nb++ ){
-
-    strbuf.append(1, buffer[pos+nb]);
-
-  }
-
-  if( strbuf == "nil" ){
-
-    PyObject* held_return = Py_None;
-    pos += 3;
-    return held_return;
-
-  } else {
-
-    PyObject* held_return = PyUnicode_Decode(strbuf.c_str(), strbuf.length(), "latin-1", "strict");
-    pos += length;
-    return held_return;
-
-  }
-
-}
-
-PyObject* etfup_atom_utf(char* buffer, int &pos){
-
-  int length = 0;
-  length = (length << 8) + buffer[pos+1];
-  length = (length << 8) + buffer[pos+2];
-  pos += 3;
-
-  std::string strbuf;
-
-  for( int nb = 0; nb < length; nb++ ){
-
-    strbuf.append(1, buffer[pos+nb]);
-
-  }
-
-  if( strbuf == "nil" ){
-
-    PyObject* held_return = Py_None;
-    pos += 3;
-    return held_return;
-
-  } else {
-
-    PyObject* held_return = PyUnicode_Decode(strbuf.c_str(), strbuf.length(), "utf-8", "strict");
-    pos += length;
-    return held_return;
-
-  }
-
-}
-
-PyObject* etfup_atom_utf_small(char* buffer, int &pos){
-
-  int length = 0;
-  length = (length << 8) + buffer[pos+1];
-  pos += 2;
-
-  std::string strbuf;
-
-  if( length ){
-
-    for( int nb = 0; nb < length; nb++ ){
-
-      strbuf.push_back(buffer[pos+nb]);
-
-    }
-
-    pos += length;
-
-  } else {
-
-    pos++;
-
-  }
-
-  if( strbuf == "nil" ){
-
-    PyObject* held_return = Py_None;
-    return held_return;
-
-  } else {
-
-    PyObject* held_return = PyUnicode_Decode(strbuf.c_str(), strbuf.length(), "utf-8", "strict");
-    return held_return;
-
-  }
-
-}
-
-PyObject* etfup_binary(char* buffer, int &pos){
-
-  int len = 0;
-  len = (len << 8) + buffer[pos+1];
-  len = (len << 8) + buffer[pos+2];
-  len = (len << 8) + buffer[pos+3];
-  len = (len << 8) + buffer[pos+4];
-  pos += 5;
-
-  std::string strbuf;
-
-  for( int nb = 0; nb < len; nb++ ){
-
-    strbuf.push_back(buffer[pos+nb]);
-
-  }
-
-  pos += len;
-  PyObject* held_return = PyUnicode_Decode(strbuf.c_str(), strbuf.length(), NULL, "strict");
-  return held_return;
-
-}
-
-PyObject* etfup_string(char* buffer, int &pos){
-
-  int len = 0;
-  len = (len << 8) + buffer[pos+1];
-  len = (len << 8) + buffer[pos+2];
-  pos += 3;
-
-  std::string strbuf;
-
-  for( int nb = 0; nb < len; nb++ ){
-
-    strbuf.push_back(buffer[pos+nb]);
-
-  }
-
-  pos += len;
-  PyObject* held_return = PyUnicode_Decode(strbuf.c_str(), strbuf.length(), NULL, "strict");
-  return held_return;
-
-}
-
-static PyObject* earl_pack(PyObject* self, PyObject *args){
-
-  std::string package;
-  Py_ssize_t len = PyTuple_Size(args);
-
-  if( !len ){
-
-    if( !PyErr_Occurred() ){
-
-      PyErr_SetString(PyExc_SyntaxError, "You must supply at least one argument.");
-
-    }
-
-    return NULL;
-
-  }
-
-  package = "\x83";
-
-  if( len > 1 ){
-
-    package += LIST_EXT;
-    package += (len & 0xFF);
-
-  }
-
-  for( int i={0}; i < len; i++ ){
-
-    PyObject* temp = PyTuple_GetItem(args, i);
-
-    if( temp == NULL ){
-
-      if( !PyErr_Occurred() ){
-
-        PyErr_SetString(PyExc_TypeError, "Earl wasn't able to unpack all your arguments for some reason.");
-
-      }
-
-      return NULL;
-
-    }
-
-    package += etf_pack_item(temp);
-
-  }
-
-  if( len > 1 and !PyErr_Occurred() ){
-
-    package += NIL_EXT;
-
-  }
-
-  if( !PyErr_Occurred() ){
-
-    return Py_BuildValue("y#", package.c_str(), package.length());
-
-  } else {
-
-    return NULL;
-
-  }
-
-}
-
-static PyObject* earl_unpack(PyObject* self, PyObject *args){
-
-    Py_ssize_t len = PyTuple_Size(args);
-
-    if ( len > 1 ){
-
-      if( !PyErr_Occurred() ){
-
-        PyErr_SetString(PyExc_RuntimeError, "Earl can only unpack one bytes object at a time.");
-
-      }
-
-    } else {
-
-        PyObject* temp = PyTuple_GetItem(args, 0);
-
-        if( PyBytes_Check(temp) ){
-
-            PyObject* final_object = etfup_bytes(temp, PyBytes_Size(temp));
-
-            if( !PyErr_Occurred() ){
-
-              return Py_BuildValue("O", final_object);
-
-            } else {
-
-              return NULL;
-
-            }
-
-        } else {
-
-            if( !PyErr_Occurred() ){
-
-                PyErr_SetString(PyExc_TypeError, "Earl can only unpack Bytes objects.");
+struct packer {
+    packer(const char* encoding, int encode_mode):
+        encoding(encoding), encode_mode(encode_mode) {}
+
+    PyObject* pack(PyObject* obj) {
+        buffer.reserve(1024 * 1024);
+        append_version();
+        if(pack_object(obj)) {
+            // error happened
+            if(PyErr_Occurred()) {
                 return NULL;
-
             }
-
+            else {
+                PyErr_SetString(earl_EncodeError, "An unknown error occurred while packing.");
+                return NULL;
+            }
         }
+        return PyBytes_FromStringAndSize(&buffer[0], buffer.size());
+    }
+private:
+    std::string buffer;
+    const char* encoding;
+    int encode_mode;
 
+    void append_version() {
+        buffer.push_back(FORMAT_VERSION);
     }
 
-    return NULL;
+    void append_nil() {
+        buffer.push_back(SMALL_ATOM_EXT);
+        buffer.push_back(3);
+        buffer.push_back('n');
+        buffer.push_back('i');
+        buffer.push_back('l');
+    }
 
+    void append_true() {
+        buffer.push_back(SMALL_ATOM_EXT);
+        buffer.push_back(4);
+        buffer.push_back('t');
+        buffer.push_back('r');
+        buffer.push_back('u');
+        buffer.push_back('e');
+    }
+
+    void append_false() {
+        buffer.push_back(SMALL_ATOM_EXT);
+        buffer.push_back(5);
+        buffer.push_back('f');
+        buffer.push_back('a');
+        buffer.push_back('l');
+        buffer.push_back('s');
+        buffer.push_back('e');
+    }
+
+    void append_small_integer(uint8_t integer) {
+        buffer.push_back(SMALL_INTEGER_EXT);
+        buffer.push_back(integer);
+    }
+
+    void append_integer(int32_t integer) {
+        unsigned char bytes[5]; // 1 + sizeof(integer)
+        bytes[0] = INTEGER_EXT;
+        as_big_endian32(bytes + 1, integer);
+        buffer.append(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    }
+
+    void append_uint64_t(uint64_t integer) {
+        unsigned char bytes[11]; // 3 + sizeof(integer)
+        pack_long_long(bytes, integer);
+        bytes[2] = 0;
+        buffer.append(reinterpret_cast<const char*>(bytes), 3 + bytes[1]);
+    }
+
+    void append_int64_t(int64_t integer) {
+        unsigned char bytes[11];
+        uint64_t value;
+        if(integer < 0) {
+            bytes[2] = 1;
+            value = -integer;
+        }
+        else {
+            bytes[2] = 0;
+            value = integer;
+        }
+        pack_long_long(bytes, value);
+        buffer.append(reinterpret_cast<const char*>(bytes), 3 + bytes[1]);
+    }
+
+    void append_double(double f) {
+        unsigned char bytes[9]; // 1 + sizeof(double)
+        bytes[0] = FLOAT_IEEE_EXT;
+        uint64_t as_number;
+        memcpy(&as_number, &f, sizeof(as_number));
+        as_big_endian64(bytes + 1, as_number);
+        buffer.append(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    }
+
+    void append_atom(const char* bytes, uint16_t size) {
+        if(size < 255) {
+            buffer.push_back(SMALL_ATOM_EXT);
+            buffer.push_back(static_cast<unsigned char>(size));
+            buffer.append(bytes, size);
+            return;
+        }
+
+        unsigned char buf[3];
+        buf[0] = ATOM_EXT;
+        as_big_endian16(buf + 1, size);
+        buffer.append(reinterpret_cast<const char*>(buf), sizeof(buf));
+        buffer.append(bytes, size);
+    }
+
+    void append_binary(const char* bytes, uint32_t size) {
+        unsigned char buf[5];
+        buf[0] = BINARY_EXT;
+        as_big_endian32(buf + 1, size);
+        buffer.append(reinterpret_cast<const char*>(buf), sizeof(buf));
+        buffer.append(bytes, size);
+    }
+
+    void append_string(const char* bytes, uint16_t size) {
+        unsigned char buf[3];
+        buf[0] = STRING_EXT;
+        as_big_endian16(buf + 1, size);
+        buffer.append(reinterpret_cast<const char*>(buf), sizeof(buf));
+        buffer.append(bytes, size);
+    }
+
+    void append_nil_ext() {
+        buffer.push_back(NIL_EXT);
+    }
+
+    void append_list_header(uint32_t size) {
+        unsigned char bytes[5];
+        bytes[0] = LIST_EXT;
+        as_big_endian32(bytes + 1, size);
+        buffer.append(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    }
+
+    void append_map_header(uint32_t size) {
+        unsigned char bytes[5];
+        bytes[0] = MAP_EXT;
+        as_big_endian32(bytes + 1, size);
+        buffer.append(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    }
+
+    void append_tuple_header(uint32_t size) {
+        if(size < 256) {
+            buffer.push_back(SMALL_TUPLE_EXT);
+            buffer.push_back(size);
+        }
+        else {
+            unsigned char bytes[5];
+            bytes[0] = LARGE_TUPLE_EXT;
+            as_big_endian32(bytes + 1, size);
+            buffer.append(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+        }
+    }
+
+    void pack_long_long(unsigned char* bytes, uint64_t value) {
+        uint8_t bytes_encoded = 0;
+        bytes[0] = SMALL_BIG_EXT;
+        while(value > 0) {
+            bytes[3 + bytes_encoded] = value & 0xFF;
+            value >>= 8;
+            ++bytes_encoded;
+        }
+        bytes[1] = bytes_encoded;
+    }
+
+    int unicode_as_atom(PyObject* str) {
+        PyObject* bytes = PyUnicode_AsUTF8String(str);
+        if(bytes == NULL || PyErr_Occurred()) {
+            Py_XDECREF(bytes);
+            return 1;
+        }
+
+        Py_ssize_t len = PyBytes_GET_SIZE(bytes);
+        if(len > UINT16_MAX) {
+            PyErr_SetString(earl_EncodeError, "string too big to encoded as ATOM_EXT");
+            Py_DECREF(bytes);
+            return 1;
+        }
+
+        append_atom(PyBytes_AS_STRING(bytes), len);
+        return 0;
+    }
+
+    int pack_object(PyObject* obj) {
+        if(obj == Py_None) {
+            append_nil();
+            return 0;
+        }
+        else if(obj == Py_False) {
+            append_false();
+            return 0;
+        }
+        else if(obj == Py_True) {
+            append_true();
+            return 0;
+        }
+        else if(PyLong_Check(obj)) {
+            int overflow;
+            long long ret = PyLong_AsLongLongAndOverflow(obj, &overflow);
+            if(ret == -1 && PyErr_Occurred()) {
+                return 1;
+            }
+
+            if(overflow == 0) {
+                // no overflow, fits perfectly in a long long so..
+                if(ret >= 0 && ret <= UINT8_MAX) {
+                    append_small_integer(ret);
+                }
+                else if(ret >= INT32_MIN && ret <= INT32_MAX) {
+                    append_integer(ret);
+                }
+                else {
+                    append_int64_t(ret);
+                }
+                return 0;
+            }
+
+            if(overflow == -1) {
+                // too small for a long long means it's too small for us
+                PyErr_SetString(earl_EncodeError, "Integer value to pack is too small.");
+                return 1;
+            }
+
+            // if overflow is 1 then it could *potentially* fit in an unsigned long long
+            unsigned long long other = PyLong_AsUnsignedLongLong(obj);
+            if(PyErr_Occurred()) {
+                return 1;
+            }
+            append_uint64_t(other);
+            return 0;
+        }
+        else if(PyFloat_Check(obj)) {
+            append_double(PyFloat_AS_DOUBLE(obj));
+            return 0;
+        }
+        else if(PyUnicode_Check(obj)) {
+            if(encode_mode == encode_type::atom) {
+                return unicode_as_atom(obj);
+            }
+
+            PyObject* bytes_obj = PyUnicode_AsEncodedString(obj, encoding, NULL);
+            if(PyErr_Occurred()) {
+                Py_XDECREF(bytes_obj);
+                return 1;
+            }
+            Py_ssize_t byte_size = PyBytes_GET_SIZE(bytes_obj);
+            if(encode_mode == encode_type::str) {
+                if(byte_size > UINT16_MAX) {
+                    PyErr_SetString(earl_EncodeError, "str is too big to be encoded as STRING_EXT");
+                    Py_DECREF(bytes_obj);
+                    return 1;
+                }
+                append_string(PyBytes_AS_STRING(bytes_obj), byte_size);
+            }
+            else {
+                if(byte_size > INT32_MAX) {
+                    PyErr_SetString(earl_EncodeError, "str is too big to be encoded as BINARY_EXT");
+                    Py_DECREF(bytes_obj);
+                    return 1;
+                }
+                append_binary(PyBytes_AS_STRING(bytes_obj), byte_size);
+            }
+            Py_DECREF(bytes_obj); // we don't need you any longer
+            return 0;
+        }
+        else if(PyTuple_Check(obj)) {
+            Py_ssize_t tuple_size = PyTuple_GET_SIZE(obj);
+            if(tuple_size > INT32_MAX) {
+                PyErr_SetString(earl_EncodeError, "tuple has too many elements");
+                return 1;
+            }
+            append_tuple_header(tuple_size);
+            for(Py_ssize_t index = 0; index < tuple_size; ++index) {
+                if(pack_object(PyTuple_GET_ITEM(obj, index))) {
+                    return 1;
+                }
+            }
+            return 0;
+        }
+        else if(PyList_Check(obj)) {
+            Py_ssize_t list_size = PyList_GET_SIZE(obj);
+            if(list_size > INT32_MAX) {
+                PyErr_SetString(earl_EncodeError, "list has too many elements");
+                return 1;
+            }
+            if(list_size == 0) {
+                append_nil_ext();
+                return 0;
+            }
+
+            append_list_header(list_size);
+            for(Py_ssize_t index = 0; index < list_size; ++index) {
+                if(pack_object(PyList_GET_ITEM(obj, index))) {
+                    return 1;
+                }
+            }
+            append_nil_ext();
+            return 0;
+        }
+        else if(PyDict_Check(obj)) {
+            Py_ssize_t dict_size = PyDict_Size(obj);
+            if(dict_size > INT32_MAX) {
+                PyErr_SetString(earl_EncodeError, "dict has too many elements");
+                return 1;
+            }
+
+            append_map_header(dict_size);
+            PyObject* key;
+            PyObject* value;
+            Py_ssize_t pos = 0;
+            while(PyDict_Next(obj, &pos, &key, &value)) {
+                if(pack_object(key) || pack_object(value)) {
+                    return 1;
+                }
+            }
+            return 0;
+        }
+        else if(PyBytes_Check(obj)) {
+            append_binary(PyBytes_AS_STRING(obj), PyBytes_GET_SIZE(obj));
+            return 0;
+        }
+        else if(PyByteArray_Check(obj)) {
+            append_binary(PyByteArray_AS_STRING(obj), PyByteArray_GET_SIZE(obj));
+            return 0;
+        }
+        else {
+            PyErr_SetString(earl_EncodeError, "unable to encode object");
+            return 1;
+        }
+    }
+};
+
+// this is an unrolled version of unpacker::get() seen below
+#define EARL_GET_UNROLLED(name) \
+    if(offset > buf.len) { \
+        return PyErr_Format(earl_DecodeError, "Unexpected end of byte string found (offset: %zd, size: %zd)", offset, buf.len); \
+    } \
+    uint8_t name = bytes[offset++]
+
+// a macro that gives a uint32_t length for use of the unpacker
+// also handles the return NULL case.
+#define EARL_GET_LENGTH \
+    const char* len = range(4); \
+    if(len == NULL) { \
+        return NULL; \
+    } \
+    uint32_t length = from_big_endian<uint32_t>(len);
+
+struct unpacker {
+    unpacker(Py_buffer buf, const char* encoding, bool encode_binary_ext):
+        buf(buf), bytes(reinterpret_cast<const char*>(buf.buf)),
+        encoding(encoding), offset(0), encode_binary_ext(encode_binary_ext) {}
+
+    PyObject* unpack() {
+        char version = bytes[offset++];
+        if(version != FORMAT_VERSION) {
+            return PyErr_Format(earl_DecodeError, "Bad version. Expected '\\x%x', found '\\x%x' instead", FORMAT_VERSION & 0xFF, version);
+        }
+
+        return decode();
+    }
+
+    ~unpacker() {
+        PyBuffer_Release(&buf);
+    }
+private:
+    Py_buffer buf;
+    const char* bytes;
+    const char* encoding;
+    Py_ssize_t offset;
+    bool encode_binary_ext;
+
+    const char* get() {
+        if(offset > buf.len) {
+            PyErr_Format(earl_DecodeError, "Unexpected end of byte string found (offset: %zd, size: %zd)", offset, buf.len);
+            return NULL;
+        }
+        return &bytes[offset++];
+    }
+
+    const char* range(Py_ssize_t count) {
+        if(offset + count > buf.len) {
+            PyErr_Format(earl_DecodeError, "Unexpected end of byte string found (offset: %zd, size: %zd, count: %zd)", offset, buf.len, count);
+            return NULL;
+        }
+        const char* copy = bytes + offset;
+        offset += count;
+        return copy;
+    }
+
+    PyObject* decode() {
+        EARL_GET_UNROLLED(op);
+        switch(op) {
+        case SMALL_INTEGER_EXT:
+            return small_int_ext();
+        case INTEGER_EXT:
+            return integer_ext();
+        case FLOAT_IEEE_EXT:
+            return float_ieee();
+        case SMALL_BIG_EXT:
+            return small_big_int();
+        case ATOM_EXT:
+            return atom_ext();
+        case SMALL_ATOM_EXT:
+            return small_atom_ext();
+        case NIL_EXT:
+            return nil_ext();
+        case SMALL_TUPLE_EXT:
+            return small_tuple_ext();
+        case LARGE_TUPLE_EXT:
+            return large_tuple_ext();
+        case LIST_EXT:
+            return list_ext();
+        case STRING_EXT:
+            return string_ext();
+        case BINARY_EXT:
+            return binary_ext();
+        case MAP_EXT:
+            return map_ext();
+        case COMPRESSED_TERM:
+            return compressed();
+        default:
+            return PyErr_Format(earl_DecodeError, "Unexpected opcode: '\\x%x'", op);
+        }
+    }
+
+    PyObject* small_int_ext() {
+        const char* byte = get();
+        return byte ? PyLong_FromUnsignedLong(static_cast<unsigned char>(*byte)) : NULL;
+    }
+
+    PyObject* integer_ext() {
+        const char* ret = range(4);
+        if(ret == NULL) {
+            return NULL;
+        }
+        int32_t x = 0;
+#if PY_BIG_ENDIAN
+        memcpy(&x, value, length);
+#else
+        char buf[4]; // enough to fill our bytes
+        char* end = &buf[3];
+        for(Py_ssize_t i = 0; i < 4; ++i) {
+            *end-- = *ret++;
+        }
+        memcpy(&x, buf, 4);
+#endif // endian check
+        return PyLong_FromLong(x);
+    }
+
+    PyObject* small_big_int() {
+        EARL_GET_UNROLLED(length);
+        const char* e = range(length + 1);
+        if(e == NULL) {
+            return NULL;
+        }
+
+        if(length > 8) {
+            return PyErr_Format(earl_DecodeError, "big integer too big to unpack, expected up to 8 bytes"
+                                                  " but received %d bytes instead", length);
+        }
+
+        return convert_big_integer(e, length);
+    }
+
+    PyObject* convert_big_integer(const char* value, Py_ssize_t length) {
+        // length does not contain the sign bit but value does
+        uint8_t sign = *value++;
+
+        // the easy ULL case
+        if(sign == 0) {
+            uint64_t ret = 0;
+#if PY_BIG_ENDIAN
+            char buf[8]; // enough to fill our bytes
+            char* end = &buf[length - 1];
+            for(Py_ssize_t i = 0; i < length; ++i) {
+                *end-- = *value++;
+            }
+            memcpy(&ret, buf, length);
+#else
+            memcpy(&ret, value, length);
+#endif // endian check
+            return PyLong_FromUnsignedLongLong(ret);
+        }
+
+        uint64_t val = 0;
+        uint64_t b = 1;
+        for(Py_ssize_t i = 0; i < length; ++i) {
+            val += static_cast<unsigned char>(*value) * b;
+            b <<= 8;
+            ++value;
+        }
+
+        PyObject* ret = PyLong_FromUnsignedLongLong(val);
+
+        // negate if necessary
+        if(sign == 0) {
+            return ret;
+        }
+        else {
+            PyObject* val = PyNumber_Negative(ret);
+            Py_DECREF(ret);
+            if(val == NULL) {
+                return NULL;
+            }
+            return val;
+        }
+    }
+
+    PyObject* float_ieee() {
+        const char* ret = range(8);
+        if(ret == NULL) {
+            return NULL;
+        }
+
+        double x;
+#if PY_BIG_ENDIAN
+        memcpy(&x, ret, 8);
+#else
+        char buf[8];
+        char* end = &buf[7];
+        for(unsigned i = 0; i < 8; ++i) {
+            *end-- = *ret++;
+        }
+        memcpy(&x, buf, 8);
+#endif // endian check
+
+        return PyFloat_FromDouble(x);
+    }
+
+    PyObject* atom_ext() {
+        const char* len_bytes = range(2);
+        if(len_bytes == NULL) {
+            return NULL;
+        }
+        uint16_t length = from_big_endian<uint16_t>(len_bytes);
+        return convert_atom(length);
+    }
+
+    PyObject* small_atom_ext() {
+        EARL_GET_UNROLLED(length);
+        return convert_atom(length);
+    }
+
+    PyObject* convert_atom(Py_ssize_t length) {
+        const char* atom = range(length);
+        if(atom == NULL) {
+            return NULL;
+        }
+
+        if(strncmp(atom, "nil", 3) == 0) {
+            Py_RETURN_NONE;
+        }
+        else if(strncmp(atom, "true", 4) == 0) {
+            Py_RETURN_TRUE;
+        }
+        else if(strncmp(atom, "false", 5) == 0) {
+            Py_RETURN_FALSE;
+        }
+
+        // we return atoms as UTF-8 encoded unicode strings
+        return PyUnicode_DecodeUTF8(atom, length, NULL);
+    }
+
+    PyObject* nil_ext() {
+        return PyList_New(0); // empty list
+    }
+
+    PyObject* small_tuple_ext() {
+        EARL_GET_UNROLLED(length);
+        return create_tuple(length);
+    }
+
+    PyObject* large_tuple_ext() {
+        EARL_GET_LENGTH
+        return create_tuple(length);
+    }
+
+    PyObject* create_tuple(Py_ssize_t length) {
+        PyObject* tuple = PyTuple_New(length);
+        if(tuple == NULL) {
+            return NULL;
+        }
+
+        for(Py_ssize_t i = 0; i < length; ++i) {
+            PyObject* element = decode();
+            if(element == NULL) {
+                Py_DECREF(tuple);
+                return NULL;
+            }
+            PyTuple_SET_ITEM(tuple, i, element);
+        }
+        return tuple;
+    }
+
+    PyObject* list_ext() {
+        EARL_GET_LENGTH
+        PyObject* list = PyList_New(length);
+        if(list == NULL) {
+            return NULL;
+        }
+
+        for(Py_ssize_t i = 0; i < length; ++i) {
+            PyObject* element = decode();
+            if(element == NULL) {
+                Py_DECREF(list);
+                return NULL;
+            }
+            PyList_SET_ITEM(list, i, element);
+        }
+
+        EARL_GET_UNROLLED(op);
+        if(op != NIL_EXT) {
+            PyErr_SetString(earl_DecodeError, "Expected NIL_EXT after list but did not receive one");
+            Py_DECREF(list);
+            return NULL;
+        }
+        return list;
+    }
+
+    PyObject* string_ext() {
+        const char* len = range(2);
+        if(len == NULL) {
+            return NULL;
+        }
+        uint16_t length = from_big_endian<uint16_t>(len);
+        const char* string_bytes = range(length);
+        if(string_bytes == NULL) {
+            return NULL;
+        }
+
+        if(encoding == NULL) {
+            // no encoding, so just return a bytes object
+            return PyBytes_FromStringAndSize(string_bytes, length);
+        }
+
+        return PyUnicode_Decode(string_bytes, length, encoding, "strict");
+    }
+
+    PyObject* binary_ext() {
+        EARL_GET_LENGTH
+        const char* string_bytes = range(length);
+        if(string_bytes == NULL) {
+            return NULL;
+        }
+        if(!encode_binary_ext || encoding == NULL) {
+            return PyBytes_FromStringAndSize(string_bytes, length);
+        }
+        return PyUnicode_Decode(string_bytes, length, encoding, "strict");
+    }
+
+    PyObject* map_ext() {
+        EARL_GET_LENGTH
+        PyObject* dict = PyDict_New();
+        if(dict == NULL) {
+            return NULL;
+        }
+
+        for(Py_ssize_t i = 0; i < length; ++i) {
+            PyObject* key = decode();
+            if(key == NULL) {
+                PyDict_Clear(dict);
+                Py_DECREF(dict);
+                return NULL;
+            }
+
+            PyObject* value = decode();
+            if(value == NULL) {
+                Py_DECREF(key);
+                PyDict_Clear(dict);
+                Py_DECREF(dict);
+                return NULL;
+            }
+
+            int ret = PyDict_SetItem(dict, key, value);
+            Py_DECREF(key);
+            Py_DECREF(value);
+
+            if(ret < 0) {
+                PyDict_Clear(dict);
+                Py_DECREF(dict);
+                return NULL;
+            }
+        }
+
+        return dict;
+    }
+
+    PyObject* compressed() {
+        EARL_GET_LENGTH
+        PyObject* zlib = PyImport_ImportModule("zlib");
+        if(zlib == NULL) {
+            return NULL;
+        }
+
+        PyObject* decompress = PyObject_GetAttrString(zlib, "decompress");
+        if(decompress == NULL) {
+            Py_DECREF(zlib);
+            return NULL;
+        }
+
+        PyObject* bytes_obj = PyBytes_FromStringAndSize(&bytes[offset], buf.len - offset);
+        if(bytes_obj == NULL) {
+            Py_DECREF(decompress);
+            Py_DECREF(zlib);
+            return NULL;
+        }
+
+        PyObject* wbits = PyLong_FromLong(15L);
+        PyObject* py_length = PyLong_FromUnsignedLong(length);
+        PyObject* args = Py_BuildValue("(OOO)", bytes_obj, wbits, py_length);
+        Py_DECREF(bytes_obj);
+        if(args == NULL) {
+            Py_XDECREF(py_length);
+            Py_DECREF(wbits);
+            Py_DECREF(decompress);
+            Py_DECREF(zlib);
+            return NULL;
+        }
+
+        PyObject* new_bytes = PyEval_CallObject(decompress, args);
+        Py_DECREF(wbits);
+        Py_DECREF(py_length);
+        Py_DECREF(args);
+        if(new_bytes == NULL) {
+            return NULL;
+        }
+
+        Py_buffer buffer;
+        if(PyObject_GetBuffer(new_bytes, &buffer, PyBUF_C_CONTIGUOUS) < 0) {
+            Py_DECREF(new_bytes);
+            Py_DECREF(decompress);
+            Py_DECREF(zlib);
+            return NULL;
+        }
+
+        // replace ourselves with the new buffer
+        this->~unpacker();
+        new(this) unpacker(buffer, encoding, encode_binary_ext);
+        PyObject* ret = decode();
+        Py_DECREF(new_bytes);
+        Py_DECREF(decompress);
+        Py_DECREF(zlib);
+        return ret;
+    }
+};
+
+#undef EARL_GET_UNROLLED
+#undef EARL_GET_LENGTH
+
+static PyObject* earl_pack(PyObject* self, PyObject* args, PyObject* kwargs) {
+    PyObject* to_pack;
+    int encode_mode = encode_type::bytes;
+    const char* encoding = "utf-8";
+    size_t len;
+
+    static const char* kwlist[] = { "obj", "encoding", "encode_mode", NULL };
+
+    if(!PyArg_ParseTupleAndKeywords(args, kwargs, "O|$s#i:pack", const_cast<char**>(kwlist),
+                                   &to_pack, &encoding, &len, &encode_mode)) {
+        return NULL;
+    }
+
+    packer p(encoding, encode_mode);
+    PyObject* ret = p.pack(to_pack);
+    return ret;
 }
 
-static char earl_pack_docs[] = "pack(values): Pack a bunch of things into an External Term Format. Multiple items or types of items are packed into a list format.";
-static char earl_unpack_docs[] = "unpack(data): Unpack ETF data. Data is unpacked according to standards and supported types.";
+static PyObject* earl_unpack(PyObject* self, PyObject* args, PyObject* kwargs) {
+    static const char* kwlist[] = { "data", "encoding", "encode_binary_ext", NULL };
+    const char* encoding = NULL;
+    size_t len;
+    int encode_binary_ext = 0;
+    Py_buffer buf;
+
+    if(!PyArg_ParseTupleAndKeywords(args, kwargs, "y*|$s#i", const_cast<char**>(kwlist),
+                                   &buf, &encoding, &len, &encode_binary_ext)) {
+        return NULL;
+    }
+
+    unpacker p(buf, encoding, encode_binary_ext);
+    PyObject* unpacked = p.unpack();
+    return unpacked;
+}
+
+static char earl_pack_docs[] = "pack(value, *, encoding=None, encode_mode=ENCODE_AS_BYTES)\n"
+                              "Packs a value to External Term Format.\n"
+                              "The encode_mode parameter is used to set how to encode unicode\n"
+                              "strings to ETF. Depending on the mode, the effect changes as follows:\n\n"
+                              "- ENCODE_AS_STR: Encodes the string with STRING_EXT\n"
+                              "- ENCODE_AS_BYTES: Encodes the string with BINARY_EXT\n"
+                              "- ENCODE_AS_ATOM: Encodes the string with ATOM_EXT (or SMALL_ATOM_EXT)\n\n"
+                              "When using ENCODE_AS_ATOM the string will be encoded into UTF-8.\n\n"
+                              "The encoding parameter denotes how to encode the unicode strings.\n"
+                              "By default, it encodes them into UTF-8.";
+static char earl_unpack_docs[] = "unpack(data, *, encoding=None, encode_binary_ext=False): Unpack ETF data.\n"
+                                "The encoding parameter specifies how to decode STRING_EXT data\n"
+                                "if encountered. If no encoding is passed, then STRING_EXT is encoded\n"
+                                "as a bytes object.\n\n If the encode_binary_ext parameter is set to True, "
+                                "then BINARY_EXT is also encoded into the encoding given.";
 
 static PyMethodDef earlmethods[] = {
-
-  {"pack", earl_pack, METH_VARARGS, earl_pack_docs},
-  {"unpack", earl_unpack, METH_VARARGS, earl_unpack_docs},
-  {NULL, NULL, 0, NULL}
-
+    {"pack", (PyCFunction)earl_pack, METH_VARARGS | METH_KEYWORDS, earl_pack_docs},
+    {"unpack", (PyCFunction)earl_unpack, METH_VARARGS | METH_KEYWORDS, earl_unpack_docs},
+    {NULL, NULL, 0, NULL}
 };
 
 static struct PyModuleDef earl = {
-
-  PyModuleDef_HEAD_INIT,
-  "earl",
-  "Earl is the fanciest External Term Format library for Python.",
-  -1,
-  earlmethods
-
+    PyModuleDef_HEAD_INIT,
+    "earl",
+    "Earl is the fanciest External Term Format library for Python.",
+    -1,
+    earlmethods
 };
 
-PyMODINIT_FUNC PyInit_earl(void){
+PyMODINIT_FUNC PyInit_earl() {
+    PyObject* mod = PyModule_Create(&earl);
+    if(mod == NULL) {
+        return NULL;
+    }
 
-  return PyModule_Create(&earl);
+    earl_EncodeError = PyErr_NewException("earl.EncodeError", PyExc_Exception, NULL);
+    if(earl_EncodeError == NULL) {
+        goto error;
+    }
 
+    earl_DecodeError = PyErr_NewException("earl.DecodeError", PyExc_Exception, NULL);
+    if(earl_DecodeError == NULL) {
+        goto error;
+    }
+
+    if(PyModule_AddObject(mod, "EncodeError", earl_EncodeError)) {
+        goto error;
+    }
+
+    if(PyModule_AddObject(mod, "DecodeError", earl_DecodeError)) {
+        goto error;
+    }
+
+    if(PyModule_AddIntConstant(mod, "ENCODE_AS_STR", encode_type::str)) {
+        goto error;
+    }
+
+    if(PyModule_AddIntConstant(mod, "ENCODE_AS_BYTES", encode_type::bytes)) {
+        goto error;
+    }
+
+    if(PyModule_AddIntConstant(mod, "ENCODE_AS_ATOM", encode_type::atom)) {
+        goto error;
+    }
+error:
+    if(PyErr_Occurred()) {
+        PyErr_SetString(PyExc_ImportError, "init failed");
+        Py_DECREF(mod);
+        mod = NULL;
+    }
+    return mod;
 }


### PR DESCRIPTION
Commit message below:

---

This new version comes with significant performance improvements,
as it now incurs as little memory allocations as possible. It also
completely refactors a lot of the code into mainly self-contained
classes.

This has been tested using discord's ETF output and it seems to
work just fine.

Since this is a significant rewrite, a lot of the API has been
changed as well.

earl.pack now only takes in a single value but allows for keyword
arguments to change its behaviour. Which adds in a couple of
constants into the module to do so. They are as follows:

- earl.ENCODE_AS_STR to encode unicode to STRING_EXT
- earl.ENCODE_AS_BYTES to encode unicode to BINARY_EXT (default)
- earl.ENCODE_AS_ATOM to encode unicode to UTF-8 ATOM_EXT

You can also now pass in the encoding parameter into earl.pack.

To make error handling more pleasant, custom exception types were
added, aptly named earl.EncodeError and earl.DecodeError. As far
as I can tell from other modules, these aren't leaked anywhere.

The unpack function also received changes like earl.pack, one of
which is the new encoding parameter. Due to Discord using the
BINARY_EXT opcode a lot to implement their string types, another
parameter was added to do the decoding in C instead of Python.
This is called encode_binary_ext as a boolean.

Also adds support for COMPRESSED_TERM and fix any bugs remaining
in the old implementation (e.g. NEW_FLOAT_EXT & co.).

---

Outside of that, this seems to have performance improvements over erlpack as well. With benchmarks showing about 2-20% speed improvements from erlpack and about 320-400% improvements from the old version of Earl.

I don't actually know how bug free this is. I've tested for memory leaks and segfaults with no issues but I'll update this PR if I find anything.