### PR TITLE
Distribution and testing-related fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@
 *.exe
 *.out
 *.app
+
+# Python artifacts
+/.cache
+/.tox
+__pycache__
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,24 @@
 from setuptools import setup, Extension
 
-module1 = Extension('earl', sources = ['earl.cpp'])
+module1 = Extension('earl', sources=['earl.cpp'])
 
-setup (
-	name = "earl-etf",
-	version = "2.1.2",
-	description = "Earl-etf, the fanciest External Term Format packer and unpacker available for Python.",
-	ext_modules = [module1],
-	url="https://github.com/ccubed/Earl",
-	author="Charles Click",
-	author_email="CharlesClick@vertinext.com",
-	license="MIT",
-	keywords="Erlang ETF External Term Format"
+setup(
+    name="earl-etf",
+    version="2.1.2",
+    description="Earl-etf, the fanciest External Term Format packer and unpacker available for Python.",
+    ext_modules=[module1],
+    test_suite='unit_tests',
+    python_requires='>=3',
+    url="https://github.com/ccubed/Earl",
+    author="Charles Click",
+    author_email="CharlesClick@vertinext.com",
+    license="MIT",
+    keywords="Erlang ETF External Term Format",
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: 3',
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py32,py33,py34,py35,py36
+
+[testenv]
+commands = {envpython} setup.py test
+deps =
+

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8; -*-
 import unittest
 import earl
 


### PR DESCRIPTION
Hello! This is a nice looking library. I'm stuck on Python 2 for now, so I think I'm out of luck, but I made a few tweaks while I was looking at it. I believe you could easily configure Travis or something to run automated tests using Tox.

- Add some items to .gitignore
- Fix some whitespace PEP8 complaints in setup.py
- Declare support for Python 3 (and not 2) in setup.py
- Declare `test_suite` in setup.py to allow `python setup.py test`
- Add some PyPA classifiers in setup.py
- Add a tox.ini file with basic config to test across Python 3
- Add file coding comment to unit_tests.py